### PR TITLE
Vibration patch

### DIFF
--- a/page/gtr-3/home/index.page.js
+++ b/page/gtr-3/home/index.page.js
@@ -201,7 +201,9 @@ Page({
   onDestroy() {
     logger.log('page onDestroy invoked')
     // localStorage.set(this.state.data)
-    timer.stopTimer(playInterval)
+    try {
+        timer.stopTimer(playInterval)
+    } catch {}
     vibrate && vibrate.stop()
 
   },

--- a/page/gts-3/home/index.page.js
+++ b/page/gts-3/home/index.page.js
@@ -201,7 +201,9 @@ Page({
   onDestroy() {
     logger.log('page onDestroy invoked')
     // localStorage.set(this.state.data)
-    timer.stopTimer(playInterval)
+    try {
+        timer.stopTimer(playInterval)
+    } catch {}
     vibrate && vibrate.stop()
 
   },


### PR DESCRIPTION
## Summary
The instance of playInterval is removed when the player has failed and is on the restart menu. When exiting the menu, vibrate.stop(playInterval) could not find an instance of playInterval and a runtime error occurs. vibrate.stop is right after this line, so the vibrate object was never destroyed, causing an error with the user's watch vibration.

Closes #3 